### PR TITLE
Interface to use naively serialised rhythms

### DIFF
--- a/example-rhythms/single-beat-splits.txt
+++ b/example-rhythms/single-beat-splits.txt
@@ -1,0 +1,28 @@
+[ Branch [ Branch [ Branch [ Single Note
+                           , Single Note
+                           ]
+                  , Single Note
+                  ]
+         , Branch [ Single Note
+                  , Single Note
+                  ]
+         ]
+, Branch [ Branch [ Single Note
+                  , Branch [ Single Note
+                           , Single Note
+                           ]
+                  ]
+         , Branch [ Single Note
+                  , Single Note
+                  ]
+         ]
+, Branch [ Branch [ Single Note
+                  , Single Note
+                  ]
+         , Branch [ Branch [ Single Note
+                           , Single Note
+                           ]
+                  , Single Note
+                  ]
+         ]
+]

--- a/example-rhythms/tresillo.txt
+++ b/example-rhythms/tresillo.txt
@@ -1,0 +1,10 @@
+[ Branch [ Single Note
+         , Branch [ Single Tie
+                  , Single Note
+                  ]
+         ]
+
+, Branch [ Single Rest
+         , Single Note
+         ]
+]

--- a/src/Exporter.hs
+++ b/src/Exporter.hs
@@ -38,4 +38,8 @@ toAscii :: RhythmTree -> String
 toAscii = drawTree . convert
     where
         convert (Branch b) = Node "" $ map convert b
-        convert (Single x) = Node (show x) [] 
+        convert (Single x) = Node (show x) []
+
+-- Serialise the RhythmTree as a naive representation of the datatype
+toRawFile :: [RhythmTree] -> FilePath -> IO ()
+toRawFile ts fp = writeFile fp (show ts)

--- a/src/Importer.hs
+++ b/src/Importer.hs
@@ -88,3 +88,12 @@ unpack = removeNulls . toDurations . sort . ((RT.Rest, 0) :) . adjust . toPositi
         -- Removes any zero length RhythmElements
         removeNulls :: [(RhythmElement, Rational)] -> [(RhythmElement, Rational)]
         removeNulls = filter ((> 0) . snd)
+
+-- Get a RhythmTree from the raw serialised ASCII (from `show`)
+-- This should only be used for experimentation and not as a proper parser
+parseRawTree :: String -> RhythmTree
+parseRawTree = read
+
+-- Get list of RhythmTrees from a file
+parseTreeFile :: FilePath -> IO [RhythmTree]
+parseTreeFile = fmap read . readFile

--- a/src/RhythmTree.hs
+++ b/src/RhythmTree.hs
@@ -6,10 +6,10 @@ import Data.List.Split
 import Data.List
 
 data RhythmElement = Note | Tie | Rest
-    deriving (Show, Eq, Enum, Bounded, Ord)
+    deriving (Show, Eq, Enum, Bounded, Ord, Read)
 
 data RhythmTree = Single RhythmElement | Branch [RhythmTree]
-    deriving (Show, Eq)
+    deriving (Show, Eq, Read)
 
 contents :: RhythmTree -> [RhythmTree]
 contents (Branch a) = a


### PR DESCRIPTION
It can be useful to use predefined rhtyhms when playing with the
Markov-chain framework. I've added a few functions to write (and read)
a naive serialisation of a RhythmTree.

I've also added two example rhythms:

example-rhythms/tresillo.txt: A common afro-cuban rhythm

example-rhythms/single-beat-splits.txt: Three different Rhythms,
each one is four beats and only _one_ beat in each rhythm is
subdivided. The hope is that a markov chain would eventually
produce the 'missing' rhythm.